### PR TITLE
Add couchdb security docs

### DIFF
--- a/db/init.js
+++ b/db/init.js
@@ -5,6 +5,7 @@ const dbsList = require('./dbs_list')
 const nano = __.require('lib', 'db/nano')
 const promises_ = __.require('lib', 'promises')
 const fs = __.require('lib', 'fs')
+const putSecurityDoc = require('./lib/put_security_doc')
 
 module.exports = function () {
   // init all dbs
@@ -18,7 +19,12 @@ const initDb = function (dbData) {
   const designDocs = dbData.designDocs
   const db = nano.use(name)
   return ensureDbExistance(name, db)
-  .then(syncDesignDocs.bind(null, db, designDocs))
+  .then(function () {
+    return promises_.all([
+      syncDesignDocs(db, designDocs),
+      putSecurityDoc(db, name)
+    ])
+  })
 }
 
 const ensureDbExistance = function (dbName, db) {

--- a/db/lib/put_security_doc.js
+++ b/db/lib/put_security_doc.js
@@ -1,0 +1,33 @@
+const CONFIG = require('config')
+const __ = CONFIG.universalPath
+const _ = __.require('lib', 'utils')
+const breq = require('bluereq')
+const dbUrl = CONFIG.store.url()
+
+module.exports = function (db, dbName) {
+  return db.get('_security')
+  .spread(function (body, headers) {
+    if (body.admins == null) {
+      const url = `${dbUrl}/${dbName}/_security`
+      _.info(dbName, 'adding security doc')
+      return breq.put(url, securityDoc())
+      .catch(_.ErrorRethrow('put security doc'))
+    }
+  })
+}
+
+const securityDoc = function () {
+  const username = CONFIG.store.username
+  if (!_.isNonEmptyString(username)) {
+    throw new Error(`bad CONFIG.db.username: ${username}`)
+  }
+  return {
+    // Database admins can update design documents
+    // and edit the admin and member lists.
+    admins: { names: [username] },
+    // Database members can access the database.
+    // If no members are defined, the database is public.
+    // Thus we just copy the admin there too to limit database access
+    members: { names: [username] }
+  }
+}


### PR DESCRIPTION
CouchDB databases access control is set from [security documents](http://docs.couchdb.org/en/1.6.1/api/database/security.html) in which admins and members should be defined.

From the CouchDB web interface:

> Database admins can update design documents and edit the admin and member lists.
> Database members can access the database. If no members are defined, the database is public.

This PR just automates setting `CONFIG.store.username` as the only admin and member for each databases. Aiming to solve #11 
