### PR TITLE
promisifying server start

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,16 +1,12 @@
 const CONFIG = require('config')
 const __ = CONFIG.universalPath
 const _ = __.require('lib', 'utils')
-const americano = require('americano')
 const initDatabases = __.require('db', 'init')
+const americano = require('americano')
+const bluebird = require('bluebird')
+const start = bluebird.promisify(americano.start)
 
 initDatabases()
-.then(function () {
-  americano.start(CONFIG.server, function (err, app, server) {
-    if (err) {
-      _.error(err, 'init err')
-    } else {
-      _.success('server started!!!')
-    }
-  })
-})
+.then(() => start(CONFIG.server))
+.then((app, server) => _.success('server started!!!'))
+.catch(_.Error('init err'))

--- a/api.js
+++ b/api.js
@@ -8,5 +8,5 @@ const start = bluebird.promisify(americano.start)
 
 initDatabases()
 .then(() => start(CONFIG.server))
-.then((app, server) => _.success('server started!!!'))
+.then((app) => _.success('server started!!!'))
 .catch(_.Error('init err'))


### PR DESCRIPTION
`americano.start` isn't aware of promises so it needs to be [promisified](http://bluebirdjs.com/docs/api/promisification.html) to stay the consistent with the rest of the code base: having callbacks in the middle of a promise chain is rather ugly and makes things seem hard to refactor
