### PR TITLE
Documentation issues

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,3 @@
 # data.transformap.co
 
-If you wish to install the daemon, please refer to the [installation documentation](/viewdocs/install)
+If you wish to install the daemon, please refer to the [installation documentation](/data.transformap.co/install)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# data.transformap.co
+
+If you wish to install the daemon, please refer to the [installation documentation](/viewdocs/install)

--- a/docs/install.md
+++ b/docs/install.md
@@ -72,6 +72,6 @@ The service should now be running.
 
 ### 4. Run a development environment
 
-    npm watch
+    npm run watch
 
 The Node Package Manager will now take care of reloading your deamon once the source code changes.


### PR DESCRIPTION
The link to viewdocs.io in README.md should be working now. Also fixed error in install.md - dev-env should be started with `npm run watch` and not `npm watch`